### PR TITLE
fix(app): change _async_display to  public method for google-colab usage

### DIFF
--- a/src/trame_common/obj/app.py
+++ b/src/trame_common/obj/app.py
@@ -1,3 +1,5 @@
+import warnings
+
 from trame.app import get_server
 
 from trame_common.exec.asynchronous import create_task
@@ -13,13 +15,39 @@ class TrameApp(TrameComponent):
     def __init__(self, server=None, client_type="vue3", ctx_name=None, **_):
         super().__init__(get_server(server, client_type=client_type), ctx_name=ctx_name)
 
+    async def display_cell(self, *, height=None, width=None):
+        from trame_client.ui.core import AbstractLayout
+
+        if not hasattr(self, "ui") or not isinstance(self.ui, AbstractLayout):
+            _error_msg = (
+                f"The 'ui' attribute of {type(self).__name__} must be an instance of "
+                "trame_client.ui.core.AbstractLayout to be compatible with Jupyter cell display."
+            )
+            raise TypeError(_error_msg)
+
+        if not hasattr(self.ui, "display_cell"):
+            await self._async_display()
+            return
+
+        await self.ui.display_cell(height=height, width=width)
+
     async def _async_display(self):
         from IPython.display import clear_output
+
+        _warn_msg = (
+            f"{type(self).__name__}._async_display() is deprecated and will be removed in a future version. "
+            "To remove this warning, please upgrade your trame_client package version."
+        )
+        warnings.warn(
+            _warn_msg,
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         await self.ui.ready
         clear_output(wait=True)
         self.ui._ipython_display_()
 
     def _repr_html_(self):
-        create_task(self._async_display())
+        create_task(self.display_cell())
         return "<i>Launching trame server in the background...</i>"


### PR DESCRIPTION
- Update the visibility of the _async_display method to public and let users change the iframe width / height on call
- Fixes display in google-colab where direct usage of _repr_html_ doesn't properly displays the iframe

This PR is related to https://github.com/Kitware/trame-client/pull/63

@jourdain trame-client is a dependency for trame-common but isn't listed in the pyproject.toml.
Should I update that with a min version?